### PR TITLE
Restore minimal mute-only implementation

### DIFF
--- a/MutePeacekeepers.lua
+++ b/MutePeacekeepers.lua
@@ -1,78 +1,66 @@
-local ADDON_NAME = ...
+-- Simple zone-based muting for Oathsworn Peacekeepers
+-- Future technical enhancements might include collecting new sound IDs at runtime
+-- or exporting the current list for analysis, but those are intentionally omitted
+-- to keep the addon lightweight in-game.
 
--- Constants for the target subzone and sound ID ranges
+-- Constants for the target zone and the known sound ID ranges
 local TARGET_ZONE = 2339
 local SOUND_RANGES = {
-	{ Start = 1393680, End = 1394257 },
-	{ Start = 567619, End = 567916 },
-
-	{ Start = 1302923, End = 1302932 },
-	{ Start = 1302596, End = 1302605 },
-	{ Start = 5919829, End = 5919837 },
-
-	{ Start = 5919829, End = 5919837 },
-	{ Start = 5919761, End = 5919779 },
-	{ Start = 5919528, End = 5919549 },
-	{ Start = 5919592, End = 5919626 },
+    { Start = 1393680, End = 1394257 },
+    { Start = 567619, End = 567916 },
+    { Start = 1302923, End = 1302932 },
+    { Start = 1302596, End = 1302605 },
+    { Start = 5919829, End = 5919837 },
+    { Start = 5919761, End = 5919779 },
+    { Start = 5919528, End = 5919549 },
+    { Start = 5919592, End = 5919626 },
 }
 
--- Boolean to keep track of whether sounds are muted or not
 local isMuted = false
 
--- Function to mute a specific sound by ID
 local function MuteSound(soundID)
-	pcall(MuteSoundFile, soundID)
+    pcall(MuteSoundFile, soundID)
 end
 
--- Function to unmute a specific sound by ID
 local function UnmuteSound(soundID)
-	pcall(UnmuteSoundFile, soundID)
+    pcall(UnmuteSoundFile, soundID)
 end
 
--- Function to mute all sounds in the defined ranges
-local function MuteSounds()
-	for _, range in ipairs(SOUND_RANGES) do
-		for soundID = range.Start, range.End do
-			MuteSound(soundID)
-		end
-	end
-	isMuted = true
+local function ApplyMuteState(shouldMute)
+    if shouldMute == isMuted then
+        return
+    end
+
+    local handler = shouldMute and MuteSound or UnmuteSound
+
+    for _, range in ipairs(SOUND_RANGES) do
+        for soundID = range.Start, range.End do
+            handler(soundID)
+        end
+    end
+
+    isMuted = shouldMute
 end
 
--- Function to unmute all sounds in the defined ranges
-local function UnmuteSounds()
-	for _, range in ipairs(SOUND_RANGES) do
-		for soundID = range.Start, range.End do
-			UnmuteSound(soundID)
-		end
-	end
-	isMuted = false
-end
-
--- Function to check the current zone and mute/unmute sounds accordingly
 local function CheckZone()
-	if C_Map.GetBestMapForUnit("player") == TARGET_ZONE then
-		if not isMuted then
-			MuteSounds()
-		end
-	else
-		if isMuted then
-			UnmuteSounds()
-		end
-	end
+    local mapID = C_Map.GetBestMapForUnit("player")
+
+    if mapID == TARGET_ZONE then
+        ApplyMuteState(true)
+    else
+        ApplyMuteState(false)
+    end
 end
 
--- Function to initialize the addon and set up event handlers
-local function InitializeAddon()
-	local frame = CreateFrame("Frame", "ContendersGateSoundMute")
-	frame:SetScript("OnEvent", CheckZone)
-	frame:RegisterEvent("ZONE_CHANGED")
-	frame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
-	frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+local function Initialize()
+    local frame = CreateFrame("Frame", "MutePeacekeepersFrame")
+    frame:SetScript("OnEvent", CheckZone)
+    frame:RegisterEvent("ZONE_CHANGED")
+    frame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+    frame:RegisterEvent("PLAYER_ENTERING_WORLD")
 
-	-- Initial check to mute/unmute sounds when the addon loads
-	C_Timer.After(1, CheckZone)
+    -- Perform an initial check after load to sync the mute state.
+    C_Timer.After(1, CheckZone)
 end
 
--- Call the initialization function when the addon is loaded
-InitializeAddon()
+Initialize()

--- a/MutePeacekeepers.toc
+++ b/MutePeacekeepers.toc
@@ -1,10 +1,10 @@
 ## Interface: 110200,110205
 
 ## Title: Mute Oathsworn Peacekeepers
-## Notes: Mutes specific NPC sounds in Contender's Gate with optional debug mode.
+## Notes: Silences Oathsworn Peacekeeper voice lines in Dornogal.
 ## IconTexture: Interface/Icons/ability_siege_engineer_automatic_repair_beam.blp
 
-## Version: 1.0.8
+## Version: 1.0.9
 
 ## Author: Kain
 ## X-Email: masterkain at gmail dot com


### PR DESCRIPTION
## Summary
- revert the addon to its minimal zone-based muting behavior without runtime configuration
- keep the curated sound ID ranges while dropping the duplicate entry and saved-variable scaffolding
- update addon metadata to reflect the pared-down implementation

## Testing
- `luac -p MutePeacekeepers.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf959ae4ec832aaf29190405f4fd67